### PR TITLE
Make G13 a gate that runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ package (`header`, `program`, `verify`, `export`, `decompile`, `strings`, `selec
 Everything under `jadart.*` submodules is implementation and may move in a minor release.
 A new Dart format epoch is a minor release, because it only ever adds binaries that parse.
 
+## Unreleased
+
+### Fixed
+
+- **G13 checks something now.** It sat in the Tier B table on every run, hardcoded to pass
+  with zero checks, waiting for a "both snapshots present" case that `verify_file` never
+  produced. It now parses the vm header alongside the isolate one and compares the vm
+  snapshot's object count against the isolate snapshot's base object count, which the VM
+  itself asserts at load. The two numbers come out of two separately parsed headers, so a
+  header misparse on either side is what would make it fail. A container with no vm
+  snapshot, such as a stripped binary found by the magic scan, gets a skip that says so.
+  Closes #3.
+
 ## 1.1.0 - 2026-09-06
 
 ### Added

--- a/framework/jadart/verify.py
+++ b/framework/jadart/verify.py
@@ -180,7 +180,7 @@ def getter_field_load(dis, recv0="x1", frame=("x15", "x29")):
     return None
 
 
-def run_gates(clusters, fr, hdr, image=None, dispatch=None) -> list:
+def run_gates(clusters, fr, hdr, image=None, dispatch=None, vm=None) -> list:
     """Evaluate every gate we can from an already-completed walk."""
     import collections
     from . import cids as C
@@ -473,11 +473,20 @@ def run_gates(clusters, fr, hdr, image=None, dispatch=None) -> list:
                             else "no getter on a compressed target to read a width from"))
 
     # ---- Tier B ------------------------------------------------------------------------
-    # G13: the isolate snapshot's base objects are the vm snapshot's objects. The VM asserts
-    # this at load with a release FATAL, so it is a real format invariant. We can check it
-    # only when both snapshots were parsed.
-    gates.append(_g("G13 base objects vs vm snapshot", "B", True, 0,
-                    skipped="checked by --verify only when both snapshots are present"))
+    # G13: the isolate snapshot's base objects are the vm snapshot's objects. The two
+    # snapshots chain: the vm one is deserialised first, and the isolate one numbers its
+    # own objects from num_base_objects + 1 (clusters.py, next_ref). The VM asserts the
+    # equality at load with a release FATAL, so it is a format invariant, and the two
+    # numbers come out of two separately parsed headers, which is what makes it a check.
+    if vm is None:
+        gates.append(_g("G13 base objects vs vm snapshot", "B", False, 0,
+                        skipped="no vm snapshot in this container"))
+    else:
+        ok = (hdr.num_base_objects == vm.num_objects)
+        rel = "==" if ok else "!="
+        gates.append(_g("G13 base objects vs vm snapshot", "B", ok, 1,
+                        f"isolate base_objects {hdr.num_base_objects} {rel} "
+                        f"vm objects {vm.num_objects}"))
 
     # G2: no unknown bits set in cluster tags.
     stray = [cl.cid for cl in clusters if cl.cid < 0]
@@ -519,8 +528,14 @@ def verify_file(path: str) -> VerifyReport:
         pos, entries, end = found
         dispatch = (pos, entries, end, image.data_length)
 
+    # The vm snapshot is a second header in the same container. parse_libapp reads both;
+    # a stripped binary found by the magic scan may carry only the isolate one, and then
+    # G13 has nothing to compare against and says so.
+    from .snapshot import parse_libapp
+    vm = parse_libapp(path, strict=False).get("vm")
+
     rep = VerifyReport(path=path, which="isolate",
                        epoch=hdr.epoch.name if hdr.epoch else "?",
                        arch=str(hdr.arch) if hdr.arch else "?")
-    rep.gates = run_gates(clusters, fr, hdr, image=image, dispatch=dispatch)
+    rep.gates = run_gates(clusters, fr, hdr, image=image, dispatch=dispatch, vm=vm)
     return rep


### PR DESCRIPTION
## What this changes

G13 checks something now. It sat in the Tier B table on every run, hardcoded to pass with zero checks, waiting for a "both snapshots present" case that `verify_file` never produced.

`verify_file` now parses the vm header alongside the isolate one and hands it to `run_gates`. G13 compares the vm snapshot's object count against the isolate snapshot's base object count. That is the chaining invariant the VM asserts at load: the vm snapshot is deserialised first, and the isolate numbers its own objects from `num_base_objects + 1`. The two values come out of two separately parsed headers, so a header misparse on either side is what would make it fail.

A container with no vm snapshot, such as a stripped binary found by the magic scan, gets a skip that says so instead of the old placeholder that skipped on every input.

Kept at Tier B, so the verdict semantics do not move. Whether it should gate the verdict is a separate call.

## Why

A gate that cannot fail is worse than no gate, because it inflates the count the verdict rests on. Closes #3.

## Tests

```
$ jadart verify flubench/artifacts/clean/lib/arm64-v8a/libapp.so -v
  [PASS] G13 base objects vs vm snapshot          1 checks  isolate base_objects 1081 == vm objects 1081
Tier A: 11/11 passed
```

- [x] Smoke run on the clean fixture
- [ ] Full `./check.sh` (not run, per the request to land the code first)
