### PR TITLE
Say what the call graph dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ A new Dart format epoch is a minor release, because it only ever adds binaries t
   header misparse on either side is what would make it fail. A container with no vm
   snapshot, such as a stripped binary found by the magic scan, gets a skip that says so.
   Closes #3.
+- **The call graph says what it dropped.** A code range that failed to decode was skipped
+  with `except Exception: continue`, so the function was simply absent from the graph and
+  every count printed beside it looked complete. Those ranges are recorded by pc on
+  `CallIndex.undecodable` now, and `functions` prints how many and which. The library
+  attribution had the same shape: one failure blanked the library column for every
+  function, indistinguishable from a snapshot that records none. It now says why, and only
+  swallows a `JadartError`; a defect in this program propagates. `function_table` returns a
+  third value, `notes`, carrying both. Closes #5.
 
 ## 1.1.0 - 2026-09-06
 

--- a/framework/jadart/callgraph.py
+++ b/framework/jadart/callgraph.py
@@ -33,6 +33,8 @@ genuinely unresolvable is a closure call through a captured context.
 """
 from dataclasses import dataclass, field
 
+from .errors import JadartError
+
 from .disasm import (CodeRange, MissingDisassembler, UnsupportedArch, disassemble_range,
                      build_pool_map, _mem_base_disp, _add_imm_from_pp)
 
@@ -62,6 +64,7 @@ class CallIndex:
     sel_targets: dict = field(default_factory=dict)        # sel off -> {target pc}
     virtual_sites: int = 0                         # blr sites attributed to a selector
     opaque_sites: int = 0                          # blr sites nothing could attribute
+    undecodable: list = field(default_factory=list)  # pcs of ranges that would not decode
 
 
 def selector_targets(image, fr, offsets, extra_names: dict = None) -> dict:
@@ -173,6 +176,11 @@ def build_index(image, fr=None, virtual: bool = True,
             # which reads as "nothing calls this" rather than "we cannot see calls here".
             raise
         except Exception:
+            # One range that will not decode must not take the graph down with it, but it
+            # must not vanish either: a function missing from the graph reads as "nothing
+            # calls this" when the truth is that nothing could look. Recorded by pc so the
+            # caller can say how many and which.
+            idx.undecodable.append(cr.pc_offset)
             continue
         src = cr.pc_offset
         if want_virtual:
@@ -266,7 +274,11 @@ ORIGINS = ("snapshot", "symtab", "signature", "anonymous")
 
 
 def function_table(image, fr, hdr=None, sigs: str = None) -> tuple:
-    """Every code range in the image as a Func. Returns (rows, graph_error).
+    """Every code range in the image as a Func. Returns (rows, graph_error, notes).
+
+    `notes` is a list of things the caller should print beside the table: ranges that
+    were dropped from the graph, or a library attribution that could not be made. They
+    are gaps in the output, and a gap that is not named reads as a fact.
 
     `graph_error` is None when the call graph was built, and the exception when it could
     not be: arm32 has no instruction decoder, and capstone is an optional extra. Both are
@@ -297,6 +309,7 @@ def function_table(image, fr, hdr=None, sigs: str = None) -> tuple:
 
     # function pc -> owning library, through the class that owns the function
     lib_by_pc = {}
+    notes = []
     if hdr is not None:
         try:
             from .program import build_program
@@ -306,8 +319,12 @@ def function_table(image, fr, hdr=None, sigs: str = None) -> tuple:
                 cr = image.code_ranges.get(ref)
                 if cr is not None and ow in lib_by_ref:
                     lib_by_pc[cr.pc_offset] = lib_by_ref[ow]
-        except Exception:
+        except JadartError as e:
+            # Every function then prints with no library, which is indistinguishable from
+            # a snapshot that records none. Say why instead. Anything that is not a
+            # JadartError is a defect in this program and propagates to the caller.
             lib_by_pc = {}
+            notes.append(f"library attribution unavailable: {e}")
 
     graph_error = None
     try:
@@ -315,6 +332,11 @@ def function_table(image, fr, hdr=None, sigs: str = None) -> tuple:
             pc: m.name for pc, m in matched.items()} if matched else None)
     except (MissingDisassembler, UnsupportedArch) as e:
         idx, graph_error = CallIndex(), e
+    if idx.undecodable:
+        shown = ", ".join(f"0x{pc:x}" for pc in idx.undecodable[:5])
+        more = f" and {len(idx.undecodable) - 5} more" if len(idx.undecodable) > 5 else ""
+        notes.append(f"{len(idx.undecodable)} code ranges would not decode and are absent "
+                     f"from the call graph: {shown}{more}")
     # How many implementations share a target's selector. 1 means a virtual site reaching
     # it has exactly one possible landing, which is as good as a direct edge.
     share = {}
@@ -342,7 +364,7 @@ def function_table(image, fr, hdr=None, sigs: str = None) -> tuple:
                         virtual_callers=len(idx.may_be_called_by.get(pc, ())),
                         overloads=share.get(pc, 0)))
     out.sort(key=lambda f: f.pc_offset)
-    return out, graph_error
+    return out, graph_error, notes
 
 
 def callers_of(image, fr, targets, extra_names: dict = None) -> dict:

--- a/framework/jadart/cli.py
+++ b/framework/jadart/cli.py
@@ -385,7 +385,7 @@ def cmd_functions(args) -> int:
     from .callgraph import function_table, ORIGINS
     try:
         image, fr, hdr = load_instructions(args.libapp)
-        table, graph_error = function_table(image, fr, hdr,
+        table, graph_error, notes = function_table(image, fr, hdr,
                                             sigs=getattr(args, "sigs", None))
     except JadartError as e:
         return _fail(e)
@@ -413,6 +413,7 @@ def cmd_functions(args) -> int:
         return emit({"ok": True, "total": len(table), "matched": len(rows),
                      "call_graph": None if graph_error else "built",
                      "call_graph_error": str(graph_error) if graph_error else None,
+                     "notes": notes,
                      "functions": [{"pc_offset": f.pc_offset, "size": f.size,
                                     "name": f.name, "label": f.label, "origin": f.origin,
                                     "library": f.library, "callers": f.callers,
@@ -432,6 +433,8 @@ def cmd_functions(args) -> int:
         # read as "nothing calls this" when the truth is that nothing could look.
         print(comment(f"// no call graph: {graph_error}"))
         print(comment("// the calls/in/vin columns are omitted rather than shown as 0"))
+    for note in notes:
+        print(comment(f"// {note}"))
     if graph_error:
         print(heading(f"{'address':<14} {'size':>7}  name"))
     else:

--- a/framework/tests/test_core.py
+++ b/framework/tests/test_core.py
@@ -4297,7 +4297,7 @@ def test_function_table_covers_every_code_range():
     from jadart.disasm import load_instructions
     from jadart.callgraph import function_table, ORIGINS
     image, fr, hdr = load_instructions(CLEAN)
-    table, graph_error = function_table(image, fr, hdr)
+    table, graph_error, _notes = function_table(image, fr, hdr)
     assert graph_error is None, f"call graph failed on arm64: {graph_error}"
     assert len(table) == len(image.all_ranges)
     assert {f.origin for f in table} <= set(ORIGINS)
@@ -4332,7 +4332,7 @@ def test_call_graph_refuses_rather_than_returning_an_empty_one():
     # flipped: a table of all-zero call counts on this binary would once again be the
     # symptom this test exists for, except now it would mean the decoder silently stopped.
     build_index(image, fr)
-    rows, graph_error = function_table(image, fr, hdr)
+    rows, graph_error, _notes = function_table(image, fr, hdr)
     assert rows, "the function list should still work: it comes from the snapshot"
     assert graph_error is None, f"arm32 decodes now; got {graph_error!r}"
     assert any(f.callees for f in rows), "no call edges at all on a binary that decodes"
@@ -4346,7 +4346,7 @@ def test_call_graph_refuses_rather_than_returning_an_empty_one():
     saved = _DECODERS.pop("arm")
     try:
         image2, fr2, hdr2 = load_instructions(arm32)
-        rows2, err2 = function_table(image2, fr2, hdr2)
+        rows2, err2, _notes2 = function_table(image2, fr2, hdr2)
         assert rows2, "the function list comes from the snapshot and must survive"
         assert isinstance(err2, UnsupportedArch), f"got {err2!r}"
         assert all(f.callers == 0 and f.callees == 0 for f in rows2)


### PR DESCRIPTION
## What this changes

Two places in `callgraph.py` hid a failure as a fact.

`build_index` skipped a code range that failed to decode with `except Exception: continue`. The function was then absent from the graph and every count printed beside it looked complete, which reads as "nothing calls this" when the truth is that nothing could look. Those ranges are recorded by pc on `CallIndex.undecodable`, and `functions` now prints how many and which. One bad range still cannot take the whole graph down, which is the right per-range behaviour; it just cannot vanish either.

The library attribution was worse. One failure blanked the library column for every function, indistinguishable from a snapshot that records none. It now says why, and it swallows only a `JadartError`. Anything else is a defect in this program and propagates to the internal-error path, the same rule the CLI already follows.

`function_table` returns a third value, `notes`, carrying both. Its four callers are updated, and `-j` carries the notes under a `notes` key.

## Why

A number the reader can see beats a silent gap. The whole tool is built on that distinction, and these two spots were on the wrong side of it. Closes #5.

## Tests

```
$ jadart functions flubench/artifacts/clean/lib/arm64-v8a/libapp.so -n 3
// 8194 code ranges  snapshot 5940  anonymous 2254
address           size  calls    in   vin  name
.text+0x80            8      0     0     -  computeDryLayout
```

On the clean fixture nothing is dropped, so no note prints and `-j` reports `"notes": []`.

- [x] Smoke run on the clean fixture, text and JSON
- [ ] Full `./check.sh` (not run, per the request to land the code first)
