### PR TITLE
Cite the coverage ssa.py actually has

### DIFF
--- a/framework/jadart/ssa.py
+++ b/framework/jadart/ssa.py
@@ -19,8 +19,15 @@ The one subtlety is loops. A loop header's back edge comes from a block that has
 lowered yet, so its phi cannot be completed when the header is first visited. Braun handles
 this with SEALING: a block is sealed once all its predecessors are known, an unsealed block
 gets an incomplete phi as a promise, and sealing fills the operands in. Getting this wrong
-does not crash, it silently drops the loop-carried value, which is exactly the class of
-bug the emulator oracle exists to catch, and `tools/irfuzz.py --whole` does catch it.
+does not crash, it silently drops the loop-carried value.
+
+What covers that today is structural: test_ssa_handles_a_loop_back_edge builds a loop by
+hand and checks the phi has both operands after sealing. There is no CPU oracle for this
+path. tools/irfuzz.py fuzzes lower_block, one basic block at a time against unicorn, and
+never calls lower_function, so a wrong join or a wrong seal that still produces a
+well-formed graph is not something the emulator gets to disagree with. That is the gap to
+close if this module ever feeds user-facing output; at the moment it feeds irfuzz and the
+tests and nothing else.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## What this changes

The `ssa.py` docstring said `tools/irfuzz.py --whole` catches a wrong seal. No such flag exists, and `irfuzz` never calls `lower_function`: it fuzzes `lower_block`, one basic block at a time against unicorn. A reader chasing that citation found an argparse error and no oracle.

The docstring now names what actually covers the sealing case, `test_ssa_handles_a_loop_back_edge`, a structural test that builds a loop by hand and checks the phi has both operands. And it says plainly that no CPU oracle covers whole-function lowering: a wrong join or seal that still yields a well-formed graph is not something the emulator gets to disagree with.

## Why

A citation that points at a check that was never written is worse than no citation. Closes #8.

The oracle gap itself stays open. This module feeds `irfuzz` and the tests and nothing user-facing, so nothing wrong reaches a user through it today. That is the reason to add a whole-function fuzz mode before that changes, not after, and it is a separate piece of work from correcting the docstring.

## Tests

Docstring only. The two `ssa` unit tests still pass:

```
3 passed, 190 deselected
```