### PR TITLE
Keep the operand caches between lifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ A new Dart format epoch is a minor release, because it only ever adds binaries t
   function, indistinguishable from a snapshot that records none. It now says why, and only
   swallows a `JadartError`; a defect in this program propagates. `function_table` returns a
   third value, `notes`, carrying both. Closes #5.
+- **The operand caches survive between lifts.** `use_target` snapshotted, cleared and
+  restored the three operand parser caches on every `lift_function` call, so every
+  function started cold and the memoisation the module spends paragraphs justifying never
+  paid: over 400 functions the cache was empty when lifting finished. It now returns early
+  when the target being bound is the one already bound, which is every arm64 lift. A real
+  switch to arm32 still clears and restores, and `export` is byte-identical with and without
+  the change. Uncached `canon()` calls over those 400 functions go from 7,771 to 1,187.
+  Closes #4.
 
 ## 1.1.0 - 2026-09-06
 

--- a/framework/jadart/expr.py
+++ b/framework/jadart/expr.py
@@ -3101,8 +3101,9 @@ def use_target(tgt: Target):
     add a second architecture without touching sixty call sites and hoping the first one
     still renders identically, and `export` on arm64 is byte-for-byte what it was.
 
-    The caches have to go with them: `sp` canonicalises to x15 on one target and r13 on
-    the other, so an entry made under one is wrong under the other. That is true of all
+    When the target actually changes, the caches have to go with it: `sp` canonicalises
+    to x15 on one target and r13 on the other, so an entry made under one is wrong under
+    the other. That is true of all
     three, not just `_CANON_CACHE`, `_MEM_CACHE` and `_DEFUSE_CACHE` store `canon()`
     results keyed on the operand STRING alone, so whichever target parsed a given string
     first would answer for both. Nothing catches it today because `LIFTABLE_ARCHS` admits
@@ -3110,6 +3111,15 @@ def use_target(tgt: Target):
     gate opens the wrong register file is a silently wrong body.
     """
     global _T, ROLE, _SPECIAL, _UNTAGGED, ARG_REGS, _CALL_CLOBBERS, _RET_USES
+    if tgt is _T:
+        # Already bound. The caches are keyed on operand text and every entry in them was
+        # made under this same target, so they are valid as they stand. Clearing them here
+        # anyway is what made every lift start cold: measured over 400 functions the cache
+        # was empty when the lifting was done, and the module had spent its memoisation
+        # paying an O(cache) snapshot and restore per function for nothing. Only a change
+        # of target invalidates anything, and that path is below.
+        yield
+        return
     prev = (_T, ROLE, _SPECIAL, _UNTAGGED, ARG_REGS, _CALL_CLOBBERS, _RET_USES,
             dict(_CANON_CACHE), dict(_MEM_CACHE), dict(_DEFUSE_CACHE))
     _T = tgt


### PR DESCRIPTION
## What this changes

`use_target` snapshotted, cleared and restored the three operand parser caches on every `lift_function` call. Every function started cold, each lift paid an O(cache) dict copy going in and coming out, and the memoisation the module header spends paragraphs justifying never paid: over 400 functions the cache was empty when lifting finished.

The clear exists for a real reason. `sp` canonicalises to x15 on arm64 and r13 on arm32, so an entry made under one target is wrong under the other. But that only matters when the target changes, and every arm64 lift rebinds ARM64 onto ARM64. `use_target` now returns early when the target being bound is the one already bound, and takes the snapshot, clear and restore path only on a real switch.

## Why

Closes #4. The memoisation was correct in design and defeated in practice by its own guard.

## Tests

Measured over the first 400 functions of the clean fixture:

```
before: 7771 uncached canon() calls, cache size 0 afterwards
after : 1187 uncached canon() calls, cache size 118 afterwards
```

The check that matters for a change on this path is that the output does not move. `jadart export` on the clean fixture, run with and without the patch:

```
files: 328 before, 328 after
export is BYTE-IDENTICAL with and without the fix
```

And the correctness argument the caches rest on still holds: binding ARM32 inside an ARM64 context serves `r13` for `sp`, and returning serves `x15` again with the arm64 cache restored.

- [x] Uncached call count, before and after
- [x] Export byte-identical
- [x] Target switch still invalidates and restores
- [ ] Full `./check.sh` (not run, per the request to land the code first)
