### PR TITLE
Give Function::Kind a name and a provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ A new Dart format epoch is a minor release, because it only ever adds binaries t
   switch to arm32 still clears and restores, and `export` is byte-identical with and without
   the change. Uncached `canon()` calls over those 400 functions go from 7,771 to 1,187.
   Closes #4.
+- **`Function::Kind` is a named table with a measured provenance.** The constructor,
+  getter and setter labels, and the instance/static receiver witnesses, were three sets of
+  bare numbers commented "for this epoch" and applied to all eighteen. They are now derived
+  by name from `FOR_EACH_RAW_FUNCTION_KIND`, and that list was fetched from `raw_object.h`
+  for every registered release, 2.19.0 through 3.12.2: all eighteen declare the same
+  seventeen kinds in the same order, so the numbers are right everywhere the tool parses.
+  A test pins the derived values, and the comment carries the two-line check to repeat
+  when a newer release is registered. Closes #6.
 
 ## 1.1.0 - 2026-09-06
 

--- a/framework/jadart/program.py
+++ b/framework/jadart/program.py
@@ -70,22 +70,44 @@ class Program:
                 if (k.class_id & 0xFFFFFFFF) >= b and k.name and not k.name.startswith("<")]
 
 
-# Dart FunctionLayout::Kind (low bits of kind_tag) for this epoch. Only the values we
-# label are listed; anything else stays a plain method.
-_FN_KIND = {5: "ctor", 3: "getter", 4: "setter"}
+# FOR_EACH_RAW_FUNCTION_KIND, raw_object.h, in declaration order. Function.kind_tag
+# carries the index in its low five bits, so this is per-release data in principle:
+# inserting a kind renumbers everything after it, and the cid table proves the SDK does
+# that between releases. In practice it has not moved. raw_object.h was fetched for every
+# one of the 18 registered releases, 2.19.0-444.2.beta through 3.12.2, and all 18 declare
+# exactly this list. When a release newer than 3.12 is registered, repeat that check:
+#
+#   from tools.sdk_source import fetch
+#   re.findall(r"V\((\w+)\)", fetch(tag, "raw_object.h").decode())  # inside the macro
+#
+# and if the list differs, this table moves onto Epoch beside the cid table.
+_FUNCTION_KINDS = (
+    "RegularFunction", "ClosureFunction", "ImplicitClosureFunction", "GetterFunction",
+    "SetterFunction", "Constructor", "ImplicitGetter", "ImplicitSetter",
+    "ImplicitStaticGetter", "FieldInitializer", "MethodExtractor",
+    "NoSuchMethodDispatcher", "InvokeFieldDispatcher", "IrregexpFunction",
+    "DynamicInvocationForwarder", "FfiTrampoline", "RecordFieldGetter",
+)
+_KIND_INDEX = {name: i for i, name in enumerate(_FUNCTION_KINDS)}
+
+# Only the kinds that get a label; anything else prints as a plain method.
+_FN_KIND = {_KIND_INDEX["Constructor"]: "ctor",
+            _KIND_INDEX["GetterFunction"]: "getter",
+            _KIND_INDEX["SetterFunction"]: "setter"}
 
 
 def _decode_fn_kind(kind_tag: int) -> str:
     return _FN_KIND.get(kind_tag & 0x1F, "method")
 
 
-# Function::Kind indices, FOR_EACH_RAW_FUNCTION_KIND in raw_object.h. The SDK's own
-# comments state the staticness of these by definition, which is what makes them usable as
-# witnesses: ImplicitGetter/ImplicitSetter are "for instance fields", MethodExtractor
-# returns "a closure on the receiver", the dispatchers and the dynamic forwarder all act on
-# a receiver, and ImplicitStaticGetter is "for static fields".
-_KIND_INSTANCE = frozenset({6, 7, 10, 11, 12, 14, 16})
-_KIND_STATIC = frozenset({8})
+# Kinds whose staticness the SDK's own comments state by definition, which is what makes
+# them usable as witnesses: ImplicitGetter/ImplicitSetter are "for instance fields",
+# MethodExtractor returns "a closure on the receiver", the dispatchers and the dynamic
+# forwarder all act on a receiver, and ImplicitStaticGetter is "for static fields".
+_KIND_INSTANCE = frozenset(_KIND_INDEX[n] for n in (
+    "ImplicitGetter", "ImplicitSetter", "MethodExtractor", "NoSuchMethodDispatcher",
+    "InvokeFieldDispatcher", "DynamicInvocationForwarder", "RecordFieldGetter"))
+_KIND_STATIC = frozenset({_KIND_INDEX["ImplicitStaticGetter"]})
 
 
 def static_bit(fr) -> int | None:

--- a/framework/tests/test_core.py
+++ b/framework/tests/test_core.py
@@ -1882,6 +1882,27 @@ def test_every_public_entry_point_raises_only_jadart_errors():
     assert not bad, "these escape `except jadart.JadartError`: " + "; ".join(bad)
 
 
+def test_function_kind_table_matches_the_sdk_enum():
+    """Function.kind_tag carries an index into FOR_EACH_RAW_FUNCTION_KIND, and the labels
+    and the receiver witnesses are derived from that list by name. The list was fetched
+    from raw_object.h for all 18 registered releases and is identical in every one, which
+    is what makes a module constant defensible here. This pins the derived numbers to the
+    values the lifter has always used, so a reordering of the list, or a release that
+    inserts a kind, shows up as a failure rather than as constructors printing as methods."""
+    from jadart.program import _FUNCTION_KINDS, _KIND_INDEX, _FN_KIND, _KIND_INSTANCE, _KIND_STATIC
+    assert len(_FUNCTION_KINDS) == 17
+    assert _FUNCTION_KINDS[0] == "RegularFunction"
+    assert _FUNCTION_KINDS[-1] == "RecordFieldGetter"
+    assert len(set(_FUNCTION_KINDS)) == 17, "a kind is listed twice"
+    # the numbers the rest of the module and the corpus tests have always relied on
+    assert _FN_KIND == {5: "ctor", 3: "getter", 4: "setter"}
+    assert _KIND_INSTANCE == frozenset({6, 7, 10, 11, 12, 14, 16})
+    assert _KIND_STATIC == frozenset({8})
+    # every witness set names a real kind, and the two sets do not overlap
+    assert not (_KIND_INSTANCE & _KIND_STATIC)
+    assert _KIND_INDEX["ImplicitStaticGetter"] in _KIND_STATIC
+
+
 def test_the_version_is_declared_once_and_the_changelog_agrees():
     # One source of truth for the number, and a record of what it means. pyproject reads
     # __version__ dynamically so those two cannot drift; the CHANGELOG is hand-written and


### PR DESCRIPTION
## What this changes

Three sets of bare numbers in `program.py` decided which functions print as `ctor`, `getter` or `setter`, and which kinds witness an instance receiver. The comment said "for this epoch" and the numbers were applied to all eighteen. `Function.kind_tag` carries an index into `FOR_EACH_RAW_FUNCTION_KIND`, and inserting a kind renumbers everything after it, so this was the one moving part that had escaped the per-epoch design.

Measured rather than assumed. `raw_object.h` was fetched for every registered release, 2.19.0-444.2.beta through 3.12.2, with `tools/sdk_source.py`, and all eighteen declare the same seventeen kinds in the same order:

```
18 releases fetched, 1 distinct enum layouts
   0 RegularFunction ... 5 Constructor ... 8 ImplicitStaticGetter ... 16 RecordFieldGetter
```

So the numbers are right for every epoch the tool parses, and a module constant is defensible. The table is now the list itself, by name, with the labels and the witness sets derived from it. The comment carries the two-line check to repeat when a release newer than 3.12 is registered, and says what to do if the list has moved: put it on `Epoch` beside the cid table.

## Why

Closes #6. The issue offered two resolutions, verify it has not moved or move it onto `Epoch`. It has not moved, so the first is the right one, and the derivation by name means the second is a small change if it ever does.

## Tests

- [x] The derived numbers equal the old literals exactly: `{5: ctor, 3: getter, 4: setter}`, instance `{6, 7, 10, 11, 12, 14, 16}`, static `{8}`. Behaviour is unchanged.
- [x] New test `test_function_kind_table_matches_the_sdk_enum` pins those values and the list's shape.
- [x] `jadart classes` still labels getters on the clean fixture.
- [ ] Full `./check.sh` (not run, per the request to land the code first)
