### PR TITLE
Test count is 194

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ You need python3 and nothing else for the core. Disassembly needs capstone.
 ```bash
 cd jadart/framework
 pip install -e '.[disasm]' pytest
-python3 -m pytest tests -q      # 193 tests, all must pass
+python3 -m pytest tests -q      # 194 tests, all must pass
 ```
 
 Use pytest, not `python3 tests/test_core.py`. The file still carries a script runner for

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![licence: MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](LICENSE)
 [![python: 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](#install)
-[![tests: 193](https://img.shields.io/badge/tests-193-brightgreen.svg)](#tests)
+[![tests: 194](https://img.shields.io/badge/tests-194-brightgreen.svg)](#tests)
 
 **A Flutter decompiler.** Point it at an APK and get back a class tree, method bodies as
 pseudo-Dart, the string pool, embedded data tables, and the source names of virtual calls.
@@ -370,7 +370,7 @@ docs/                 usage, support, and the Flutter internals explainer
 ## Tests
 
 ```bash
-cd framework && python3 -m pytest tests -q     # 193 tests
+cd framework && python3 -m pytest tests -q     # 194 tests
 ./check.sh                                     # the suite, the gates, the measured claims
 ./check.sh --full                              # adds the CFG edge check and determinism
 ```
@@ -378,7 +378,7 @@ cd framework && python3 -m pytest tests -q     # 193 tests
 Some tests need something this repository does not ship: a multi-version corpus, an
 `--obfuscate` build of another app, `unicorn` for the differential oracles. Those skip
 with the reason named, and pytest reports them as skips rather than passes. On a fresh
-clone with capstone installed, expect around 175 to run.
+clone with capstone installed, expect around 177 to run.
 
 The arm64 FluBench fixtures, clean and `--obfuscate`, are committed, so a fresh clone runs
 the suite with no Flutter install. Tests whose fixture is missing skip and say which one.

--- a/framework/README.md
+++ b/framework/README.md
@@ -286,7 +286,7 @@ tightened only by the next `_kDart*` boundary symbol in that same section.
 ## Tests
 
 ```bash
-python3 -m pytest tests -q     # 193 tests
+python3 -m pytest tests -q     # 194 tests
 ```
 
 The arm64 FluBench Dart 3.12.2 fixtures are committed, so a fresh clone runs the suite


### PR DESCRIPTION
## What this changes

The badge, two comments quoting the count, and the note on how many tests run on a fresh clone. One test came in with #14 and they were all still on 193.

## Why

`measure.py --check` fails when a doc quotes a count the suite does not have. That is the point of checking it rather than trusting it.

## Tests

`./check.sh --full` passes end to end: 177 passed, 17 skipped, both fixtures 11/11 and 9/9 with Tier B now 3/3 since G13 runs, 0 edge violations, export byte-identical across two hash seeds.